### PR TITLE
Disable http cache to reduce hf allocation

### DIFF
--- a/benchmarks/get-all-heroes/get-all-heroes.hf.yaml
+++ b/benchmarks/get-all-heroes/get-all-heroes.hf.yaml
@@ -16,6 +16,7 @@ http:
     host: !param SERVICE_HOST localhost
     port: !param SERVICE_PORT 8083
     sharedConnections: !param SHARED_CONNECTIONS 400
+    useHttpCache: false
 
 phases:
   - getAllHeroes:

--- a/benchmarks/get-all-villains/get-all-villains.hf.yaml
+++ b/benchmarks/get-all-villains/get-all-villains.hf.yaml
@@ -16,6 +16,7 @@ http:
     host: !param SERVICE_HOST localhost
     port: !param SERVICE_PORT 8084
     sharedConnections: !param SHARED_CONNECTIONS 400
+    useHttpCache: false
 
 phases:
   - getAllVillains:

--- a/benchmarks/get-random-hero/get-random-hero.hf.yaml
+++ b/benchmarks/get-random-hero/get-random-hero.hf.yaml
@@ -14,6 +14,7 @@ http:
     host: !param SERVICE_HOST localhost
     port: !param SERVICE_PORT 8083
     sharedConnections: !param SHARED_CONNECTIONS 400
+    useHttpCache: false
 
 phases:
   - randomHero:

--- a/benchmarks/get-random-villain/get-random-villain.hf.yaml
+++ b/benchmarks/get-random-villain/get-random-villain.hf.yaml
@@ -14,6 +14,7 @@ http:
     host: !param SERVICE_HOST localhost
     port: !param SERVICE_PORT 8084
     sharedConnections: !param SHARED_CONNECTIONS 400
+    useHttpCache: false
 
 phases:
   - randomVillain:

--- a/benchmarks/perform-fights/perform-fights.hf.yaml
+++ b/benchmarks/perform-fights/perform-fights.hf.yaml
@@ -21,6 +21,7 @@ http:
     host: !param SERVICE_HOST localhost
     port: !param SERVICE_PORT 8082
     sharedConnections: !param SHARED_CONNECTIONS 400
+    useHttpCache: false
 
 phases:
   - performFight:


### PR DESCRIPTION
As stated in [hyperfoil.io/docs/user-guide/benchmark/http/](https://hyperfoil.io/docs/user-guide/benchmark/http/) we can disable the http cache on HF side as not required. This should reduce the allocation required by HF.