### PR TITLE
Enable perf record for native apps profiling

### DIFF
--- a/modes/custom.native.build.script.yaml
+++ b/modes/custom.native.build.script.yaml
@@ -58,14 +58,13 @@ scripts:
   - set-state: LOCATIONS_GRPC_IMAGE "quay.io/quarkus-super-heroes/grpc-locations:${{SUPERHEROES_CUSTOM_TAG}}"
   - set-state: FIGHTS_REST_IMAGE "quay.io/quarkus-super-heroes/rest-fights:${{SUPERHEROES_CUSTOM_TAG}}"
 
-
 states:
   IS_NATIVE: true
   SUPERHEROES_BUILD_REPO: https://github.com/quarkusio/quarkus-super-heroes.git
   SUPERHEROES_BUILD_COMMIT: main
   SUPERHEROES_BUILD_FOLDER: /tmp/build-quarkus-super-heroes
 
-  SUPERHEROES_CUSTOM_TAG: local-main
+  SUPERHEROES_CUSTOM_TAG: native-debuginfo
 
   # change these values
   CONTAINER_RUNTIME_PARAMS:

--- a/modes/native.debuginfo.script.yaml
+++ b/modes/native.debuginfo.script.yaml
@@ -1,0 +1,22 @@
+scripts:
+  prepare-images:
+  - log: nothing to do as images are already available in quay.io
+
+states:
+  IS_NATIVE: true
+  
+  # we are interested in fights only, so let's use just that one as rebuilt
+  HEROES_REST_IMAGE: "quay.io/quarkus-super-heroes/rest-heroes:native-latest"
+  VILLAINS_REST_IMAGE: "quay.io/quarkus-super-heroes/rest-villains:native-latest"
+  LOCATIONS_GRPC_IMAGE: "quay.io/quarkus-super-heroes/grpc-locations:native-latest"
+  # image obtained running custom.native.build script with docker
+  FIGHTS_REST_IMAGE: "quay.io/alampare/rest-fights:native-debuginfo"
+
+  # change these values
+  CONTAINER_RUNTIME_PARAMS:
+
+  # different entrypoint
+  # HEROES_NATIVE_ENTRYPOINT: rest-heroes-1.0-runner
+  # VILLAINS_NATIVE_ENTRYPOINT: rest-villains-1.0-runner
+  # LOCATIONS_NATIVE_ENTRYPOINT: grpc-locations-1.0-runner
+  FIGHTS_NATIVE_ENTRYPOINT: rest-fights-1.0-runner

--- a/profiling.yaml
+++ b/profiling.yaml
@@ -102,13 +102,21 @@ scripts:
     - wait-for: HF_BENCHMARK_TERMINATED
       then:
       - sh: kill ${MPSTAT_PID} || echo "mpstat already stopped"
+  
+  # application profiling
+  app-prof-setup:
+  - js: ${{APP_PROF_ENABLED}}
+    then:
+    - sh: ${{SUDOER}} sh -c "echo 1 > /proc/sys/kernel/perf_event_paranoid" || echo "Unable to set perf_event_paranoid"
+    - sh: ${{SUDOER}} sh -c "echo 0 > /proc/sys/kernel/kptr_restrict" || echo "Unable to unset kptr_restrict"
+    - js: ${{IS_NATIVE}}
+      else:
+      - script: asprof-setup
 
   # async profiler
   asprof-setup:
   - js: ${{APP_PROF_ENABLED}}
     then:
-    - sh: ${{SUDOER}} sh -c "echo 1 > /proc/sys/kernel/perf_event_paranoid" || echo "Unable to set perf_event_paranoid"
-    - sh: ${{SUDOER}} sh -c "echo 0 > /proc/sys/kernel/kptr_restrict" || echo "Unable to unset kptr_restrict"
     # override container runtimes to include asprof volumes
     - set-state: CONTAINER_RUNTIME_PARAMS ${{CONTAINER_RUNTIME_PARAMS}} -v ${{ASPROF_DIR}}:${{ASPROF_DIR}}:rw,Z -v ${{ASPROF_OUT_DIR}}:${{ASPROF_OUT_DIR}}:rw,Z 
     - sh: if [ -d ${{ASPROF_DIR}} ]; then rm -rf ${{ASPROF_DIR}}; fi
@@ -121,23 +129,51 @@ scripts:
     - sh: if [ -d ${{ASPROF_OUT_DIR}} ]; then rm -rf ${{ASPROF_OUT_DIR}}; fi
     - sh: mkdir -p ${{ASPROF_OUT_DIR}} && chmod 777 ${{ASPROF_OUT_DIR}} || echo "Cannot create ${{ASPROF_OUT_DIR}} directory"
   
+  run-app-prof:
+  - js: ${{APP_PROF_ENABLED}}
+    then:
+    - js: ${{IS_NATIVE}}
+      then:
+      - script: run-perfrecord
+      else:
+      - script: run-asprof
+
+  run-perfrecord:
+    # APP_PID_STATE:      the pid of the JVM process to profile
+    # APP_SERVICE:        service to monitor FIGHTS, HEROES, VILLAINS or LOCATIONS
+  - wait-for: HF_BENCHMARK_STARTED
+  - log: Starting application level profiling for native ${{${{APP_PID_STATE}}}}...
+  - sh: 
+      command: ${{SUDOER}} ls -la /work
+      ignore-exit-code: true
+  - sh: ${{SUDOER}} perf record ${{PERFRECORD_PARAMS}} -o /tmp/${{APP_SERVICE}}_perfrecord.data -p ${{${{APP_PID_STATE}}}}
+    on-signal:
+      # stop perf when the HF load terminates
+      HF_BENCHMARK_TERMINATED:
+      - ctrlC
+  - sh: ${{SUDOER}} perf script -i /tmp/${{APP_SERVICE}}_perfrecord.data >> /tmp/${{APP_SERVICE}}_perfrecord-script.txt
+  # - sh: ${{SUDOER}} perf report -i /tmp/${{APP_SERVICE}}_perfrecord.data >> /tmp/${{APP_SERVICE}}_perfrecord-report.txt
+  - queue-download: /tmp/${{APP_SERVICE}}_perfrecord.data
+  - queue-download: /tmp/${{APP_SERVICE}}_perfrecord-script.txt
+  # - queue-download: /tmp/${{APP_SERVICE}}_perfrecord-report.txt
+  # remove the /work emulation if present
+  - sh: if [ -d /work ]; then rm -rf /work || echo "Cannot remove /work directory"; fi
+
   run-asprof:
     # Relies on existing async-profiler exectuable located at ASPROF_EXEC
     # APP_PID_STATE:      the pid of the JVM process to profile
-    # APP_SERVICE:        service to monitor with perf stat FIGHTS, HEROES, VILLAINS or LOCATIONS
-  - js: ${{APP_PROF_ENABLED}}
-    then:
-    - wait-for: HF_BENCHMARK_STARTED
-    - log: Starting application level profiling for ${{${{APP_PID_STATE}}}}...
-    - sh: ${{SUDOER}} ${{ASPROF_EXEC:/tmp/async-profiler/bin/asprof}} start -e ${{ASPROF_EVENT}} --fdtransfer ${{ASPROF_PARAMS:}} ${{${{APP_PID_STATE}}}}
-    - log: Async profiler started, waiting for HF_BENCHMARK_TERMINATED stop signal...
-    - wait-for: HF_BENCHMARK_TERMINATED
-    - sh: ${{SUDOER}} ${{ASPROF_EXEC:/tmp/async-profiler/bin/asprof}} stop -f ${{ASPROF_OUT_DIR}}/${{APP_SERVICE:service}}_asprof -o ${{ASPROF_FORMAT:flamegraph}} --title '${{APP_SERVICE:service}} ${{ASPROF_EVENT}} profiling' ${{${{APP_PID_STATE}}}}
-    - log: Stopped application level profiling
-    # Rename the output file based on the provided format file extension
-    - set-state: FILE_EXTENSION ${{= ${{ASPROF_FORMATS}}['${{ASPROF_FORMAT:flamegraph}}'] }}
-    - sh: mv ${{ASPROF_OUT_DIR}}/${{APP_SERVICE:service}}_asprof ${{ASPROF_OUT_DIR}}/${{APP_SERVICE:service}}_asprof.${{FILE_EXTENSION}}
-    - queue-download: ${{ASPROF_OUT_DIR}}/${{APP_SERVICE:service}}_asprof.${{FILE_EXTENSION}}
+    # APP_SERVICE:        service to monitor FIGHTS, HEROES, VILLAINS or LOCATIONS
+  - wait-for: HF_BENCHMARK_STARTED
+  - log: Starting application level profiling for JVM ${{${{APP_PID_STATE}}}}...
+  - sh: ${{SUDOER}} ${{ASPROF_EXEC:/tmp/async-profiler/bin/asprof}} start -e ${{ASPROF_EVENT}} --fdtransfer ${{ASPROF_PARAMS:}} ${{${{APP_PID_STATE}}}}
+  - log: Async profiler started, waiting for HF_BENCHMARK_TERMINATED stop signal...
+  - wait-for: HF_BENCHMARK_TERMINATED
+  - sh: ${{SUDOER}} ${{ASPROF_EXEC:/tmp/async-profiler/bin/asprof}} stop -f ${{ASPROF_OUT_DIR}}/${{APP_SERVICE:service}}_asprof -o ${{ASPROF_FORMAT:flamegraph}} --title '${{APP_SERVICE:service}} ${{ASPROF_EVENT}} profiling' ${{${{APP_PID_STATE}}}}
+  - log: Stopped application level profiling
+  # Rename the output file based on the provided format file extension
+  - set-state: FILE_EXTENSION ${{= ${{ASPROF_FORMATS}}['${{ASPROF_FORMAT:flamegraph}}'] }}
+  - sh: mv ${{ASPROF_OUT_DIR}}/${{APP_SERVICE:service}}_asprof ${{ASPROF_OUT_DIR}}/${{APP_SERVICE:service}}_asprof.${{FILE_EXTENSION}}
+  - queue-download: ${{ASPROF_OUT_DIR}}/${{APP_SERVICE:service}}_asprof.${{FILE_EXTENSION}}
   
   # parse the metrics from the generated profiling files and set them to 
   # qDup states so that they can easily be exported
@@ -219,7 +255,9 @@ states:
   MPSTAT_ENABLED: true
   MPSTAT_PARAMS: "-P ALL 1"
 
+  # in according to the stack it will use either perf record or asprof
   APP_PROF_ENABLED: false
+
   ASPROF_RELEASE_URL: https://github.com/async-profiler/async-profiler/releases/download/v${{ASPROF_VERSION:3.0}}/async-profiler-${{ASPROF_VERSION:3.0}}-linux-x64.tar.gz
   ASPROF_VERSION: "3.0"
   ASPROF_DIR: /tmp/async-profiler
@@ -232,3 +270,5 @@ states:
       "jfr": "jfr",
       "flamegraph": "html"
     }
+
+  PERFRECORD_PARAMS: -e cpu-clock -F 100 --call-graph dwarf

--- a/qdup.yaml
+++ b/qdup.yaml
@@ -51,7 +51,7 @@ roles:
     hosts:
       - sut
     setup-scripts:
-      - asprof-setup
+      - app-prof-setup
     run-scripts:
       - run-pidstat
       - run-vmstat
@@ -61,7 +61,7 @@ roles:
       - run-perfstat:
           with:
             PERFSTAT_SERVICE: FIGHTS
-      - run-asprof:
+      - run-app-prof:
           with:
             APP_PID_STATE: HOST.FIGHTS_REST_PID
             APP_SERVICE: FIGHTS

--- a/superheroes.yaml
+++ b/superheroes.yaml
@@ -150,7 +150,7 @@ scripts:
         -e JAVA_OPTS_APPEND="${{JAVA_OPTS_APPEND:}}"
         ${{= getNetwork( '${{SUT_SERVER}}' ) }}
         ${{HEROES_REST_IMAGE:'quay.io/quarkus-super-heroes/rest-heroes:native-latest'}}
-        ${{= ${{IS_NATIVE:false}} ? "./application ${{JAVA_OPTS_APPEND:}}" : '' }}
+        ${{= ${{IS_NATIVE:false}} ? "./${{HEROES_NATIVE_ENTRYPOINT}} ${{JAVA_OPTS_APPEND:}}" : '' }}
       then:
       - regex: (?<HOST.HEROES_REST_POD_ID>[a-f0-9]{64}$)
         else:
@@ -224,7 +224,7 @@ scripts:
         -e JAVA_OPTS_APPEND="${{JAVA_OPTS_APPEND:}}"
         ${{= getNetwork( '${{SUT_SERVER}}' ) }}
         ${{VILLAINS_REST_IMAGE:'quay.io/quarkus-super-heroes/rest-villains:native-latest'}}
-        ${{= ${{IS_NATIVE:false}} ? "./application ${{JAVA_OPTS_APPEND:}}" : '' }}
+        ${{= ${{IS_NATIVE:false}} ? "./${{VILLAINS_NATIVE_ENTRYPOINT}} ${{JAVA_OPTS_APPEND:}}" : '' }}
       then:
       - regex: (?<HOST.VILLAINS_REST_POD_ID>[a-f0-9]{64}$)
         else:
@@ -301,7 +301,7 @@ scripts:
         -e JAVA_OPTS_APPEND="${{JAVA_OPTS_APPEND:}}"
         ${{= getNetwork( '${{SUT_SERVER}}' ) }}
         ${{LOCATIONS_GRPC_IMAGE:'quay.io/quarkus-super-heroes/grpc-locations:native-latest'}}
-        ${{= ${{IS_NATIVE:false}} ? "./application ${{JAVA_OPTS_APPEND:}}" : '' }}
+        ${{= ${{IS_NATIVE:false}} ? "./${{LOCATIONS_NATIVE_ENTRYPOINT}} ${{JAVA_OPTS_APPEND:}}" : '' }}
       then:
       - regex: (?<HOST.LOCATIONS_GRPC_POD_ID>[a-f0-9]{64}$)
         else:
@@ -434,7 +434,7 @@ scripts:
         -e JAVA_OPTS_APPEND="${{JAVA_OPTS_APPEND:}}"
         ${{= getNetwork( '${{SUT_SERVER}}' ) }}
         ${{FIGHTS_REST_IMAGE:'quay.io/quarkus-super-heroes/rest-fights:native-latest'}}
-        ${{= ${{IS_NATIVE:false}} ? "./application ${{JAVA_OPTS_APPEND:}}" : '' }}
+        ${{= ${{IS_NATIVE:false}} ? "./${{FIGHTS_NATIVE_ENTRYPOINT}} ${{JAVA_OPTS_APPEND:}}" : '' }}
       then:
       - regex: (?<HOST.FIGHTS_REST_POD_ID>[a-f0-9]{64}$)
         else:
@@ -452,6 +452,11 @@ scripts:
       timer:
         1m: # max wait time
         - abort: Fights rest service has not been ready in 1 min
+    - js: ${{IS_NATIVE}} && ${{APP_PROF_ENABLED}}
+      then:
+      # we need to copy the /work in the host (this most likely require root privileges)
+      - sh: if [ -d /work ]; then rm -rf /work; fi
+      - sh: ${{CONTAINER_RUNTIME}} cp ${{HOST.FIGHTS_REST_POD_ID}}:/work /work
     - signal: FIGHTS_REST_READY
 
   start-fights-ui:
@@ -589,6 +594,7 @@ states:
   HEROES_DB_LOGS_FILE: /tmp/heroes_db.logs
 
   HEROES_REST_IMAGE: "quay.io/quarkus-super-heroes/rest-heroes:native-latest"
+  HEROES_NATIVE_ENTRYPOINT: application
   HEROES_REST_HOSTNAME: 
   HEROES_REST_PORT: 8083
   HEROES_REST_LOGS_FILE: /tmp/heroes.logs
@@ -603,6 +609,7 @@ states:
   VILLAINS_DB_LOGS_FILE: /tmp/villains_db.logs
 
   VILLAINS_REST_IMAGE: "quay.io/quarkus-super-heroes/rest-villains:native-latest"
+  VILLAINS_NATIVE_ENTRYPOINT: application
   VILLAINS_REST_HOSTNAME: 
   VILLAINS_REST_PORT: 8084
   VILLAINS_REST_LOGS_FILE: /tmp/villains.logs
@@ -617,6 +624,7 @@ states:
   LOCATIONS_DB_LOGS_FILE: /tmp/locations_db.logs
 
   LOCATIONS_GRPC_IMAGE: "quay.io/quarkus-super-heroes/grpc-locations:native-latest"
+  LOCATIONS_NATIVE_ENTRYPOINT: application
   LOCATIONS_GRPC_HOSTNAME: 
   LOCATIONS_GRPC_PORT: 8089
   LOCATIONS_GRPC_LOGS_FILE: /tmp/locations.logs
@@ -641,6 +649,7 @@ states:
   KAFKA_LOGS_FILE: /tmp/kafka.logs
 
   FIGHTS_REST_IMAGE: "quay.io/quarkus-super-heroes/rest-fights:native-latest"
+  FIGHTS_NATIVE_ENTRYPOINT: application
   FIGHTS_REST_HOSTNAME: 
   FIGHTS_REST_PORT: 8082
   FIGHTS_REST_LOGS_FILE: /tmp/fights.logs


### PR DESCRIPTION
Changes:
- [x] Setup `perf record` when using native images to obtain the flamegraph
- [x] Copy the native image `/work` folder in the host machine (this is required by perf record to be properly working)

Relies on `IS_NATIVE` state to consider a run with native images

> NOTE: to get a valid flamegraph the native image should be built some additional parameters to keep debug symbols and shipped with the `.debug` file (a tentative is the `custom.native.script` mode)