### PR TITLE
Increase the allowed number of open files during checkpoint.

### DIFF
--- a/modes/semeru.build.script.yaml
+++ b/modes/semeru.build.script.yaml
@@ -69,22 +69,22 @@ scripts:
       -pl ${{= getProjects( ${{HEROES_ENABLED}}, ${{VILLAINS_ENABLED}}, ${{LOCATIONS_ENABLED}}, ${{FIGHTS_ENABLED}} )}} | tee /tmp/superheroes.build.log
   - sh: > 
        if ${{HEROES_ENABLED}}; then
-         ${{CONTAINER_RUNTIME}} build -f ./rest-heroes/src/main/docker/Dockerfile.jvm -t quay.io/quarkus-super-heroes/rest-heroes:${{SUPERHEROES_CUSTOM_TAG}} --cap-add=ALL --security-opt seccomp=unconfined \
+         ${{CONTAINER_RUNTIME}} build --ulimit=nofile=1048576:1048576 -f ./rest-heroes/src/main/docker/Dockerfile.jvm -t quay.io/quarkus-super-heroes/rest-heroes:${{SUPERHEROES_CUSTOM_TAG}} --cap-add=ALL --security-opt seccomp=unconfined \
          --network host --build-arg=DS_SERVER=${{= getHostname( '${{DS_SERVER}}' )}} --memory 1G --cpuset-cpus ${{HEROES_REST_CPU}} ./rest-heroes/ | tee -a /tmp/superheroes.build.log;
        fi
   - sh: >
        if ${{VILLAINS_ENABLED}}; then
-         ${{CONTAINER_RUNTIME}} build -f ./rest-villains/src/main/docker/Dockerfile.jvm -t quay.io/quarkus-super-heroes/rest-villains:${{SUPERHEROES_CUSTOM_TAG}} --cap-add=ALL --security-opt seccomp=unconfined \
+         ${{CONTAINER_RUNTIME}} build --ulimit=nofile=1048576:1048576 -f ./rest-villains/src/main/docker/Dockerfile.jvm -t quay.io/quarkus-super-heroes/rest-villains:${{SUPERHEROES_CUSTOM_TAG}} --cap-add=ALL --security-opt seccomp=unconfined \
          --network host --build-arg=DS_SERVER=${{= getHostname( '${{DS_SERVER}}' )}} --memory 1G --cpuset-cpus ${{VILLAINS_REST_CPU}} ./rest-villains/ | tee -a /tmp/superheroes.build.log;
        fi
   - sh: >
        if ${{LOCATIONS_ENABLED}}; then
-         ${{CONTAINER_RUNTIME}} build -f ./grpc-locations/src/main/docker/Dockerfile.jvm -t quay.io/quarkus-super-heroes/grpc-locations:${{SUPERHEROES_CUSTOM_TAG}} --cap-add=ALL --security-opt seccomp=unconfined \
+         ${{CONTAINER_RUNTIME}} build --ulimit=nofile=1048576:1048576 -f ./grpc-locations/src/main/docker/Dockerfile.jvm -t quay.io/quarkus-super-heroes/grpc-locations:${{SUPERHEROES_CUSTOM_TAG}} --cap-add=ALL --security-opt seccomp=unconfined \
          --network host --build-arg=DS_SERVER=${{= getHostname( '${{DS_SERVER}}' )}} --memory 1G --cpuset-cpus ${{LOCATIONS_GRPC_CPU}} ./grpc-locations/ | tee -a /tmp/superheroes.build.log;
        fi
   - sh: >
        if ${{FIGHTS_ENABLED}}; then
-         ${{CONTAINER_RUNTIME}} build -f ./rest-fights/src/main/docker/Dockerfile.jvm -t quay.io/quarkus-super-heroes/rest-fights:${{SUPERHEROES_CUSTOM_TAG}} --cap-add=ALL --security-opt seccomp=unconfined \
+         ${{CONTAINER_RUNTIME}} build --ulimit=nofile=1048576:1048576 -f ./rest-fights/src/main/docker/Dockerfile.jvm -t quay.io/quarkus-super-heroes/rest-fights:${{SUPERHEROES_CUSTOM_TAG}} --cap-add=ALL --security-opt seccomp=unconfined \
          --network host --build-arg=DS_SERVER=${{= getHostname( '${{DS_SERVER}}' )}} \
          --build-arg=SUT_SERVER=${{= getHostname( '${{SUT_SERVER}}' )}} --memory 1G --cpuset-cpus ${{FIGHTS_REST_CPU}} ./rest-fights/ --memory 1G | tee -a /tmp/superheroes.build.log;
        fi


### PR DESCRIPTION
It looks like by default, the `podman build` command allows 1024 open files. This causes a problem because the checkpoint  is done during a `podman build`, so the checkpoint process has a limit of 1024 open files, and this limit carries forward to when the process is restored. 

So, when you run the benchmark with many shared connections (>1000), the process quickly has "too many open files", and fails.

The solution is to add a ulimit to the `podman build` command. 