### PR TITLE
Add optional jitserver for semeru

### DIFF
--- a/modes/assets/semeru/Dockerfile.fights.semeru
+++ b/modes/assets/semeru/Dockerfile.fights.semeru
@@ -66,7 +66,7 @@ COPY --chown=185 target/quarkus-app/quarkus/ /deployments/quarkus/
 
 EXPOSE 8083
 
-ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+UseJITServer -XX:JITServerAddress=${SUT_SERVER}"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 
 RUN mkdir -p /etc/criu && echo tcp-close >>/etc/criu/default.conf

--- a/modes/assets/semeru/Dockerfile.heroes.semeru
+++ b/modes/assets/semeru/Dockerfile.heroes.semeru
@@ -36,6 +36,8 @@ WORKDIR /app
 RUN chown -R 185 /app/ && chmod -R 777 /app/
 
 ARG DS_SERVER=localhost
+ARG SUT_SERVER=localhost
+
 ENV QUARKUS_DATASOURCE_REACTIVE_URL=postgresql://${DS_SERVER}:5432/heroes_database
 ENV QUARKUS_HIBERNATE_ORM_DATABASE_GENERATION=validate
 ENV QUARKUS_DATASOURCE_USERNAME=superman
@@ -63,7 +65,7 @@ USER 185
 
 EXPOSE 8083
 
-ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+UseJITServer -XX:JITServerAddress=${SUT_SERVER}"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 
 # Create checkpoint

--- a/modes/assets/semeru/Dockerfile.locations.semeru
+++ b/modes/assets/semeru/Dockerfile.locations.semeru
@@ -36,6 +36,7 @@ WORKDIR /app
 RUN chown -R 185 /app/ && chmod -R 777 /app/
 
 ARG DS_SERVER=localhost
+ARG SUT_SERVER=localhost
 
 ENV QUARKUS_DATASOURCE_JDBC_URL=jdbc:mariadb://${DS_SERVER}:3306/locations_database
 ENV QUARKUS_HIBERNATE_ORM_DATABASE_GENERATION=validate
@@ -64,7 +65,7 @@ USER 185
 
 EXPOSE 8083
 
-ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+UseJITServer -XX:JITServerAddress=${SUT_SERVER}"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 
 RUN ./start-quarkus.sh

--- a/modes/assets/semeru/Dockerfile.villains.semeru
+++ b/modes/assets/semeru/Dockerfile.villains.semeru
@@ -36,6 +36,7 @@ WORKDIR /app
 RUN chown -R 185 /app/ && chmod -R 777 /app/
 
 ARG DS_SERVER=localhost
+ARG SUT_SERVER=localhost
 
 ENV QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://${DS_SERVER}:5433/villains_database
 ENV QUARKUS_HIBERNATE_ORM_DATABASE_GENERATION=validate
@@ -64,7 +65,7 @@ USER 185
 
 EXPOSE 8084
 
-ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTS_APPEND="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+UseJITServer -XX:JITServerAddress=${SUT_SERVER}"
 ENV JAVA_APP_JAR="/deployments/quarkus-run.jar"
 
 #Create Checkpoint

--- a/modes/semeru.build.script.yaml
+++ b/modes/semeru.build.script.yaml
@@ -70,17 +70,20 @@ scripts:
   - sh: > 
        if ${{HEROES_ENABLED}}; then
          ${{CONTAINER_RUNTIME}} build --ulimit=nofile=1048576:1048576 -f ./rest-heroes/src/main/docker/Dockerfile.jvm -t quay.io/quarkus-super-heroes/rest-heroes:${{SUPERHEROES_CUSTOM_TAG}} --cap-add=ALL --security-opt seccomp=unconfined \
-         --network host --build-arg=DS_SERVER=${{= getHostname( '${{DS_SERVER}}' )}} --memory 1G --cpuset-cpus ${{HEROES_REST_CPU}} ./rest-heroes/ | tee -a /tmp/superheroes.build.log;
+         --network host --build-arg=DS_SERVER=${{= getHostname( '${{DS_SERVER}}' )}} \
+         --build-arg=SUT_SERVER=${{= getHostname( '${{SUT_SERVER}}' )}} --memory 1G --cpuset-cpus ${{HEROES_REST_CPU}} ./rest-heroes/ | tee -a /tmp/superheroes.build.log;
        fi
   - sh: >
        if ${{VILLAINS_ENABLED}}; then
          ${{CONTAINER_RUNTIME}} build --ulimit=nofile=1048576:1048576 -f ./rest-villains/src/main/docker/Dockerfile.jvm -t quay.io/quarkus-super-heroes/rest-villains:${{SUPERHEROES_CUSTOM_TAG}} --cap-add=ALL --security-opt seccomp=unconfined \
-         --network host --build-arg=DS_SERVER=${{= getHostname( '${{DS_SERVER}}' )}} --memory 1G --cpuset-cpus ${{VILLAINS_REST_CPU}} ./rest-villains/ | tee -a /tmp/superheroes.build.log;
+         --network host --build-arg=DS_SERVER=${{= getHostname( '${{DS_SERVER}}' )}} \
+         --build-arg=SUT_SERVER=${{= getHostname( '${{SUT_SERVER}}' )}} --memory 1G --cpuset-cpus ${{VILLAINS_REST_CPU}} ./rest-villains/ | tee -a /tmp/superheroes.build.log;
        fi
   - sh: >
        if ${{LOCATIONS_ENABLED}}; then
          ${{CONTAINER_RUNTIME}} build --ulimit=nofile=1048576:1048576 -f ./grpc-locations/src/main/docker/Dockerfile.jvm -t quay.io/quarkus-super-heroes/grpc-locations:${{SUPERHEROES_CUSTOM_TAG}} --cap-add=ALL --security-opt seccomp=unconfined \
-         --network host --build-arg=DS_SERVER=${{= getHostname( '${{DS_SERVER}}' )}} --memory 1G --cpuset-cpus ${{LOCATIONS_GRPC_CPU}} ./grpc-locations/ | tee -a /tmp/superheroes.build.log;
+         --network host --build-arg=DS_SERVER=${{= getHostname( '${{DS_SERVER}}' )}} \
+        --build-arg=SUT_SERVER=${{= getHostname( '${{SUT_SERVER}}' )}} --memory 1G --cpuset-cpus ${{LOCATIONS_GRPC_CPU}} ./grpc-locations/ | tee -a /tmp/superheroes.build.log;
        fi
   - sh: >
        if ${{FIGHTS_ENABLED}}; then

--- a/qdup.yaml
+++ b/qdup.yaml
@@ -30,6 +30,7 @@ roles:
       - prepare-images # should be exposed by script files in /modes folder
       - infer-datastouce-hostnames
       - infer-services-hostnames
+      - start-jit-server
       - start-heroes-rest
       - start-villains-rest
       - start-locations-grpc

--- a/qdup.yaml
+++ b/qdup.yaml
@@ -27,10 +27,10 @@ roles:
     hosts:
       - sut
     setup-scripts:
+      - start-jit-server
       - prepare-images # should be exposed by script files in /modes folder
       - infer-datastouce-hostnames
       - infer-services-hostnames
-      - start-jit-server
       - start-heroes-rest
       - start-villains-rest
       - start-locations-grpc

--- a/superheroes.yaml
+++ b/superheroes.yaml
@@ -109,7 +109,7 @@ scripts:
         -p ${{JIT_SERVER_PORT}}:38400
         ${{= getNetwork( '${{SUT_SERVER}}' ) }}
         ${{JIT_SERVER_IMAGE:'icr.io/appcafe/ibm-semeru-runtimes:open-21-jdk-ubi9-minimal'}}
-        "jitserver" 
+        jitserver -XX:+JITServerLogConnections
       then:
       - regex: (?<HOST.JIT_SERVER_POD_ID>[a-f0-9]{64}$)
         else:

--- a/superheroes.yaml
+++ b/superheroes.yaml
@@ -27,6 +27,7 @@ scripts:
 
   infer-services-hostnames:
   # infer the hostnames based on the provided host servers
+  - set-state: JIT_SERVER_HOSTNAME "${{= getHostname( '${{SUT_SERVER}}' )}}"
   - set-state: HEROES_REST_HOSTNAME "${{= getHostname( '${{SUT_SERVER}}' )}}"
   - set-state: VILLAINS_REST_HOSTNAME "${{= getHostname( '${{SUT_SERVER}}' )}}"
   - set-state: LOCATIONS_GRPC_HOSTNAME "${{= getHostname( '${{SUT_SERVER}}' )}}"
@@ -94,6 +95,40 @@ scripts:
       1m: # max wait time
       - abort: Opentelemetry has not been ready in 1 min
   - signal: OTEL_READY
+
+  ###### JITSERVER ######
+  start-jit-server:
+  - js: ${{JIT_SERVER_ENABLED}}
+    then:
+    - log: starting jit server...
+    - sh: >
+        ${{CONTAINER_RUNTIME}} run -d
+        --name jit-server
+        --memory ${{JIT_SERVER_MEMORY}}
+        --cpuset-cpus ${{JIT_SERVER_CPU}}
+        -p ${{JIT_SERVER_PORT}}:38400
+        ${{= getNetwork( '${{SUT_SERVER}}' ) }}
+        ${{JIT_SERVER_IMAGE:'icr.io/appcafe/ibm-semeru-runtimes:open-21-jdk-ubi9-minimal'}}
+        "jitserver" 
+      then:
+      - regex: (?<HOST.JIT_SERVER_POD_ID>[a-f0-9]{64}$)
+        else:
+        - abort: failed to capture pod id for Jit Server service
+      - script: extract-service-pid
+        with:
+          CONTAINER_ID: ${{HOST.JIT_SERVER_POD_ID}}
+          STATE_PID: HOST.JIT_SERVER_PID
+          IS_ENTRYPOINT_WRAPPER: false
+    - sh: ${{CONTAINER_RUNTIME}} logs -f ${{HOST.JIT_SERVER_POD_ID}}
+      silent: true # prevent logs to be printed in the terminal
+      watch:
+      - regex: JITServer is ready
+        then:
+        - ctrlC
+      timer:
+        1m: # max wait time
+        - abort: Jit Server has not been ready in 1 min
+    - signal: JIT_SERVER_READY
 
   ###### HEROES ######
 
@@ -561,9 +596,15 @@ scripts:
       then:
       - queue-download: ${{HEROES_REST_LOGS_FILE}}
       - sh: ${{CONTAINER_RUNTIME}} logs ${{HOST.HEROES_REST_POD_ID}} > ${{HEROES_REST_LOGS_FILE}}
+  - js: ${{JIT_SERVER_ENABLED}}
+    then:
+    - read-state: ${{HOST.JIT_SERVER_POD_ID}}
+      then:
+      - queue-download: ${{JIT_SERVER_LOGS_FILE}}
+      - sh: ${{CONTAINER_RUNTIME}} logs ${{HOST.JIT_SERVER_POD_ID}} > ${{JIT_SERVER_LOGS_FILE}}
 
   # remove all pods
-  - sh: ${{CONTAINER_RUNTIME}} rm -f ${{HOST.FIGHTS_REST_UI_ID:}} ${{HOST.FIGHTS_REST_POD_ID:}} ${{HOST.VILLAINS_REST_POD_ID:}} ${{HOST.HEROES_REST_POD_ID:}} ${{HOST.LOCATIONS_GRPC_POD_ID:}}
+  - sh: ${{CONTAINER_RUNTIME}} rm -f ${{HOST.FIGHTS_REST_UI_ID:}} ${{HOST.FIGHTS_REST_POD_ID:}} ${{HOST.VILLAINS_REST_POD_ID:}} ${{HOST.HEROES_REST_POD_ID:}} ${{HOST.LOCATIONS_GRPC_POD_ID:}} ${{HOST.JIT_SERVER_POD_ID:}}
 
 states:
   # container exec
@@ -655,6 +696,15 @@ states:
   FIGHTS_REST_LOGS_FILE: /tmp/fights.logs
   FIGHTS_REST_MEMORY: 1G
   FIGHTS_REST_CPU: 4
+
+    # Heroes
+  JIT_SERVER_ENABLED: false
+  JIT_SERVER_IMAGE: "icr.io/appcafe/ibm-semeru-runtimes:open-21-jdk-ubi9-minimal"
+  JIT_SERVER_HOSTNAME:
+  JIT_SERVER_PORT: 38400
+  JIT_SERVER_LOGS_FILE: /tmp/jitserver.logs
+  JIT_SERVER_MEMORY: 4G
+  JIT_SERVER_CPU: 5-8
 
   UI_ENABLED: true
   FIGHTS_UI_IMAGE: "quay.io/quarkus-super-heroes/ui-super-heroes:native-latest"


### PR DESCRIPTION
To enable: `-S JIT_SERVER_ENABLED=true`

By default, cpus 5-8 and 4g are used for the JIT Server Container. This can be changed with:

  `-S JIT_SERVER_CPU=`
 ` -S JIT_SERVER_MEMORY=`
  